### PR TITLE
[require] Check the body argument to see if it's a function before trying to call .apply on it in a multi-dependency require statement

### DIFF
--- a/require.js
+++ b/require.js
@@ -82,16 +82,18 @@
             }
             deps = [deps, ];
         }
-        if (deps.length === 0)
+        if (deps.length === 0 && _.isFunction(body)){
             // no dependencies, so run immediately
             body.apply(undefined, deps);
+        }
         // prepare for resolving dependencies
         var todo = deps.length, _deps = _.clone(deps);
         var resolve = function (data, i) {
             _deps[i] = data;
-            if (--todo <= 0)
+            if (--todo <= 0 && _.isFunction(body)){
                 // everything is resolved now, so we can process the body of our request
                 body.apply(undefined, _deps);
+            }
         };
         _.each(deps, function (name, i) {
             load(get(name), function (data) {


### PR DESCRIPTION
This addresses an issue where if you require two modules simply for their side effects and you don't need to pass a callback you get an error, whereas if you make two separate require calls for them, with no callback each time, it works fine.

Calling `_.isFunction(body)` before trying to call `body.apply(...)` should do the trick. Passing a no-op callback works as well, but this seems nicer.
##### Example...

``` javascript
// This works
if (Meteor.isClient){
  require('router');
  require('titleSetter');
}

// This errors
if (Meteor.isClient){
  require(['router', 'titleSetter']);
}
```
##### Here's a screenshot of the error...

![screen shot 2013-05-11 at 4 32 49 pm](https://f.cloud.github.com/assets/427516/492275/450169aa-ba93-11e2-937c-6360c926cb5c.png)

Let me know if this seems reasonable. Thanks!

Alex
