### PR TITLE
Exported the `define` and `require` symbols

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,4 +6,7 @@ Package.describe({
 Package.on_use(function (api) {
     api.use('underscore', ['client', 'server']);
     api.add_files('require.js', ['client', 'server']);
+
+    api.export('define', ['client', 'server']);
+    api.export('require', ['client', 'server']);
 });


### PR DESCRIPTION
Because these functions aren't explicitly exported, using this as a package (as opposed to a flat JS file in lib/compatability) gives undefined reference errors.
