### PR TITLE
Export symbols from Meteor package

### DIFF
--- a/package.js
+++ b/package.js
@@ -6,4 +6,6 @@ Package.describe({
 Package.on_use(function (api) {
     api.use('underscore', ['client', 'server']);
     api.add_files('require.js', ['client', 'server']);
+    api.export('require');
+    api.export('define');
 });


### PR DESCRIPTION
The current version of Meteor (0.6.5) requires that packages export their public symbols, which broke require. This change exports the symbols 'require' and 'define' from the package.
